### PR TITLE
link to Snowfall Flake fixed

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -160,7 +160,7 @@ import {
 				name="Snowfall Flake"
 				description="Simplified Nix Flakes on the command line."
 				icon="/images/nix.svg"
-				link="https://github.com/snowfallorg/lib"
+				link="https://github.com/snowfallorg/flake"
 				classes={{
 					icon: "invert dark:invert-0",
 				}}


### PR DESCRIPTION
Snowfall Lib and Snowfall Flake are now linking to their different repositories.